### PR TITLE
Upgrade to rpaframework 13

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -9,5 +9,5 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      # Define pip packages here.
-    - rpaframework==10.9.0
+    # Define pip packages here.
+    - rpaframework==13.0.0

--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,0 +1,4 @@
+{
+    "EMAIL_RECIPIENT": "cosmin@robocorp.com",
+    "OUTLOOK_ACCOUNT": "cosmin@robocorp.com"
+}


### PR DESCRIPTION
Fixes `comtypes` importing issue (SyntaxError) due to more recent `rpaframework` upgrade. Tested on Windows 11 and the mail sending works flawlessly.